### PR TITLE
Bugfix/#8 list side blank space

### DIFF
--- a/gallerywidget.cpp
+++ b/gallerywidget.cpp
@@ -23,13 +23,14 @@ GalleryWidget::GalleryWidget(QWidget *parent) :
     ui->listView->setItemDelegate(new ImageDelegate(this));
 
     ui->listView->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    ui->listView ->verticalScrollBar()->setSingleStep(25);
-
+    ui->listView->verticalScrollBar()->setSingleStep(25);
+    ui->listView->verticalScrollBar()->setStyleSheet("QScrollBar:vertical { width: 20px; }");
+    ui->listView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 }
 
 void GalleryWidget::resizeEvent(QResizeEvent *event) {
     QListView* listView = ui->listView;
-    realListWidth = listView->width() - listView->verticalScrollBar()->width();
+    realListWidth = listView->contentsRect().width() - 20;
 
     QSettings settings;
     QString path = settings.value("main_path").toString();

--- a/gallerywidget.cpp
+++ b/gallerywidget.cpp
@@ -29,8 +29,9 @@ GalleryWidget::GalleryWidget(QWidget *parent) :
 }
 
 void GalleryWidget::resizeEvent(QResizeEvent *event) {
+    QWidget::resizeEvent(event);
     QListView* listView = ui->listView;
-    realListWidth = listView->contentsRect().width() - 20;
+    realListWidth = listView->contentsRect().width() - listView->verticalScrollBar()->sizeHint().width();
 
     QSettings settings;
     QString path = settings.value("main_path").toString();
@@ -39,7 +40,7 @@ void GalleryWidget::resizeEvent(QResizeEvent *event) {
     }
 
     qDebug() << "List width:" << listView->width();
-    qDebug() << "Scrollbar width:" << listView->verticalScrollBar()->width();
+    qDebug() << "Scrollbar width:" << listView->verticalScrollBar()->sizeHint().width();
 }
 
 GalleryWidget::~GalleryWidget()

--- a/gallerywidget.h
+++ b/gallerywidget.h
@@ -28,7 +28,7 @@ private:
 
     int realListWidth;
 
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 
     void calculateListSize(std::vector<Image*>& list, int columnWidth);
     void calculateCollageSizes(std::vector<Image*>& list);

--- a/gallerywidget.ui
+++ b/gallerywidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>401</width>
+    <width>400</width>
     <height>300</height>
    </rect>
   </property>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -122,8 +122,8 @@
      <rect>
       <x>30</x>
       <y>80</y>
-      <width>721</width>
-      <height>481</height>
+      <width>720</width>
+      <height>480</height>
      </rect>
     </property>
    </widget>


### PR DESCRIPTION
Closes #18.
The solution was done in a hacky way, the list width wasn't reliable because of the scrollbar so we set a fixed width for the scrollbar and with that, the accurate width was calculated.