### PR TITLE
Fixed lag in the list with big images.

### DIFF
--- a/gallerywidget.cpp
+++ b/gallerywidget.cpp
@@ -78,6 +78,7 @@ void GalleryWidget::setLayoutType(const QString& layoutType) {
     for (auto image: rawList) {
         newList.push_back(new Image(*image));
     }
+    mListModel->resetThumbnails();
 
     if (layoutType == "Grid view") {
         listView->setFlow(QListView::LeftToRight);
@@ -113,6 +114,8 @@ void GalleryWidget::calculateListSize(std::vector<Image*>& list, int columnWidth
             image->setWidth(columnWidth);
             image->setHeight(newHeight);
         }
+        auto path = QString::fromStdString(image->fileUrl());
+        mListModel->generateThumbnail(path, QSize(image->width(), image->height()));
     }
 }
 
@@ -168,5 +171,8 @@ void GalleryWidget::normalizeHeights(std::vector<Image *>& images, int count, in
         int width = height * getAspectRatio(size);
         image->setWidth(width);
         image->setHeight(height);
+
+        auto path = QString::fromStdString(image->fileUrl());
+        mListModel->generateThumbnail(path, QSize(width, height));
     }
 }

--- a/imagedelegate.cpp
+++ b/imagedelegate.cpp
@@ -13,12 +13,7 @@ void ImageDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option,
 {
     painter->save();
 
-    QString path = index.model()->data(index, Qt::DisplayRole).toString();
-
-    QPixmap original(path);
-    QSize size = index.model()->data(index, Qt::SizeHintRole).value<QSize>();
-
-    QPixmap pixmap = original.scaled(size);
+    QPixmap pixmap = index.model()->data(index, Qt::DecorationRole).value<QPixmap>();
     painter->drawPixmap(option.rect.x(), option.rect.y(), pixmap);
 
     painter->restore();

--- a/imagemodel.cpp
+++ b/imagemodel.cpp
@@ -1,10 +1,10 @@
 
 #include "imagemodel.h"
-#include "qsize.h"
 
 
 ImageModel::ImageModel(QObject *parent) :
-    images{}
+    images{},
+    mThumbnails()
 {
 
 }
@@ -25,7 +25,11 @@ QVariant ImageModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole:
         return QString::fromStdString(picture.fileUrl());
         break;
-
+    case Qt::DecorationRole: {
+        auto filepath = QString::fromStdString(picture.fileUrl());
+        return *mThumbnails[filepath];
+        break;
+    }
     case Qt::SizeHintRole:
         return QSize(picture.width(), picture.height()) ;
         break;
@@ -48,6 +52,20 @@ void ImageModel::setImageList(std::vector<Image*> newImages)
     beginResetModel();
     images = newImages;
     endResetModel();
+}
+
+void ImageModel::resetThumbnails()
+{
+    qDeleteAll(mThumbnails);
+    mThumbnails.clear();
+}
+
+void ImageModel::generateThumbnail(QString filePath, QSize size)
+{
+    QPixmap original(filePath);
+    auto thumbnail = new QPixmap(original.scaled(size));
+    qDebug() << "Thumbnail path:" << filePath << thumbnail;
+    mThumbnails.insert(filePath, thumbnail);
 }
 
 bool ImageModel::isIndexValid(const QModelIndex& index) const

--- a/imagemodel.h
+++ b/imagemodel.h
@@ -3,7 +3,9 @@
 #define IMAGEMODEL_H
 
 #include "image.h"
+#include "qsize.h"
 #include <QAbstractListModel>
+#include <QPixmap>
 
 
 
@@ -18,10 +20,13 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
     void setImageList(std::vector<Image*> newImages);
+    void resetThumbnails();
+    void generateThumbnail(QString filePath, QSize size);
 private:
     bool isIndexValid(const QModelIndex& index) const;
 
     std::vector<Image*> images;
+    QHash<QString, QPixmap*> mThumbnails;
 };
 
 #endif // IMAGEMODEL_H


### PR DESCRIPTION
Instead of loading the images in the delegate they are now loaded and resized before setting the model items. The thumbnails are then passed to the delegate.

A few things to keep in mind:
- The app now uses more memory because all the images are loaded (this can be improved by not loading all the images at once but on demand).
- The initial loading is now longer, same for changing layout types. The app is irresponsive while loading, it would be better if we change the loading to a background thread.

Closes #10.